### PR TITLE
Change scroll behaviour on modal toggle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -37,6 +37,6 @@
 	body {
 		margin: 0;
 		height: 100%;
-		overflow-y: overlay;
+		overflow-y: scroll;
 	}
 </style>

--- a/src/components/sign-in-modal/SignInModal.vue
+++ b/src/components/sign-in-modal/SignInModal.vue
@@ -158,11 +158,13 @@ export default {
 	mounted() {
 		// prevent  scrolling
 		document.body.style.overflowY = "hidden";
+		document.body.style.marginRight = "17px";
 		document.addEventListener("keydown", this.handleEscapeClickedEvent);
 	},
 	beforeDestroy() {
 		this.clearData();
-		document.body.style.overflowY = "overlay";
+		document.body.style.overflowY = "scroll";
+		document.body.style.marginRight = "0";
 		document.removeEventListener("keydown", this.handleEscapeClickedEvent);
 	},
 	methods: {


### PR DESCRIPTION
When modal is toggled scrolling is disabled. The problem was that  on closing modal, scrolling was disabled infinitely on Firefox.

Vertical scrollbar is now always visible, to support proper behaviour in Firefox.